### PR TITLE
Use hostname verifier directly instead of instance DO NOT MERGE

### DIFF
--- a/core/java/android/net/SSLCertificateSocketFactory.java
+++ b/core/java/android/net/SSLCertificateSocketFactory.java
@@ -81,9 +81,6 @@ public class SSLCertificateSocketFactory extends SSLSocketFactory {
         }
     };
 
-    private static final HostnameVerifier HOSTNAME_VERIFIER =
-        HttpsURLConnection.getDefaultHostnameVerifier();
-
     private SSLSocketFactory mInsecureFactory = null;
     private SSLSocketFactory mSecureFactory = null;
     private TrustManager[] mTrustManagers = null;
@@ -195,7 +192,7 @@ public class SSLCertificateSocketFactory extends SSLSocketFactory {
             if (session == null) {
                 throw new SSLException("Cannot verify SSL socket without session");
             }
-            if (!HOSTNAME_VERIFIER.verify(hostname, session)) {
+            if (!HttpsURLConnection.getDefaultHostnameVerifier().verify(hostname, session)) {
                 throw new SSLPeerUnverifiedException("Cannot verify hostname: " + hostname);
             }
         }


### PR DESCRIPTION
Instead of local instance of the default HostnameVerifier, use it
directly from HttpsURLConnection. This avoids class preloading creating
an instance of it before it's necessary.

(cherry picked from commit 928ee1e48fa89302d02fdf8a8a2c7315d7195e7c)

Bug: 9984058
Change-Id: I79d8a934bfc390e4cd503fd592e21bc4e5446a7d
